### PR TITLE
Fix MC_THREAD_SIG handler replacement during thread recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all : minicriu libminicriu-client.a
 
 minicriu : minicriu.o
 minicriu : LDFLAGS += -static
+minicriu : LDLIBS += -lpthread
 minicriu.o : CFLAGS += -fPIE
 
 minicriu-client.o : CFLAGS += -fPIC


### PR DESCRIPTION
Add thread synchronization during recovery in order to avoid MC_THREAD_SIG handler replacement. Now all threads are calling the desired MC_THREAD_SIG handler.
