### PR TITLE
Add correct memory map of .bss segment and protection to the mapped regions

### DIFF
--- a/minicriu.c
+++ b/minicriu.c
@@ -272,6 +272,12 @@ int main(int argc, char *argv[]) {
 			continue;
 		}
 		pread(fd, (void*)ph->p_vaddr, ph->p_filesz, ph->p_offset);
+
+		int mprot = 0;
+		mprot |= ph->p_flags & PF_R ? PROT_READ : 0;
+		mprot |= ph->p_flags & PF_W ? PROT_WRITE : 0;
+		mprot |= ph->p_flags & PF_X ? PROT_EXEC : 0;
+		mprotect((void*)ph->p_vaddr, ph->p_memsz, mprot);
 	}
 
 	struct sigaction sa = {

--- a/minicriu.c
+++ b/minicriu.c
@@ -183,12 +183,12 @@ int main(int argc, char *argv[]) {
 		if (ph->p_type != PT_LOAD) {
 			continue;
 		}
-		if (munmap((void*)ph->p_vaddr, ph->p_filesz)) {
+		if (munmap((void*)ph->p_vaddr, ph->p_memsz)) {
 			/*perror("munmap");*/
 		}
 		void *addr = mmap((void*)ph->p_vaddr,
-				ph->p_filesz,
-				PROT_READ | PROT_WRITE | PROT_EXEC,
+				ph->p_memsz,
+				PROT_WRITE,
 				MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS,
 				-1, 0);
 		if (addr != (void*)ph->p_vaddr) {

--- a/minicriu.c
+++ b/minicriu.c
@@ -186,11 +186,11 @@ int main(int argc, char *argv[]) {
 		if (munmap((void*)ph->p_vaddr, ph->p_memsz)) {
 			/*perror("munmap");*/
 		}
-		void *addr = mmap((void*)ph->p_vaddr,
-				ph->p_memsz,
-				PROT_WRITE,
-				MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS,
-				-1, 0);
+		void *addr = mmap((void *)ph->p_vaddr,
+						  ph->p_memsz,
+						  PROT_WRITE | PROT_READ,
+						  MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS,
+						  -1, 0);
 		if (addr != (void*)ph->p_vaddr) {
 			if (addr == MAP_FAILED) {
 				fprintf(stderr, "WARN: mmap phdr vaddr %16llx filesz %16llx off %16llx: %m\n",


### PR DESCRIPTION
Fix an issue where a .bss segment was not mapped to memory, causing SIGSEGV to be called during recovery and provide restrictions to the mapped regions according to the permissions on sections in the program header. 