### PR TITLE
Fix the test in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ set-core-pattern :
 
 core : test file
 	grep '^/tmp/core.%p$$' /proc/sys/kernel/core_pattern # assume the specific core_pattern
-	export LD_LIBRARY_PATH=$$PWD; ./$< & p=$$!; wait; mv /tmp/core.$$p $@
+	export LD_LIBRARY_PATH=$$PWD; bash -c 'echo $$$$ > /tmp/test.pid; ulimit -c unlimited; exec ./$<'; mv /tmp/core.$$(cat /tmp/test.pid) $@
+	rm /tmp/test.pid
 
 sim-run : test
 	gdb -q -batch -ex 'handle SIGABRT noprint nostop nopass' -ex 'run' ./test


### PR DESCRIPTION
Provide the correct execution of the test in the makefile, as the SIGINT and SIGQUIT signals are no longer ignored