### PR TITLE
Implementation of the ELF format dumper (resolved conflicts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 #  Copyright 2017-2022 Azul Systems, Inc.
-# 
+#
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
-# 
+#
 #  1. Redistributions of source code must retain the above copyright notice,
 #  this list of conditions and the following disclaimer.
-# 
+#
 #  2. Redistributions in binary form must reproduce the above copyright notice,
 #  this list of conditions and the following disclaimer in the documentation
 #  and/or other materials provided with the distribution.
-# 
+#
 #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 #  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 #  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -23,23 +23,21 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 
 CFLAGS = -g -MMD -MT $@ -MF $@.d
+LDLIBS+= -lpthread -lcap
 ASFLAGS = $(CFLAGS)
 
 all : minicriu libminicriu-client.a
 
 minicriu : minicriu.o
 minicriu : LDFLAGS += -static
-minicriu : LDLIBS += -lpthread
 minicriu.o : CFLAGS += -fPIE
 
-minicriu-client : LDLIBS += -lpthread
 minicriu-client.o : CFLAGS += -fPIC
 
 libminicriu-client.a : minicriu-client.o
 	ar rcs $@ $^
 
 test : test.o libminicriu-client.a libshared.so
-test : LDLIBS += -lpthread
 
 shared.o : CFLAGS += -fPIC
 
@@ -53,7 +51,7 @@ set-core-pattern :
 	echo /tmp/core.%p | sudo tee /proc/sys/kernel/core_pattern
 
 core : test file
-	export LD_LIBRARY_PATH=$$PWD; exec ./$<; 
+	export LD_LIBRARY_PATH=$$PWD; exec ./$<;
 
 sim-run : test
 	gdb -q -batch -ex 'handle SIGABRT noprint nostop nopass' -ex 'run' ./test

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ minicriu : LDFLAGS += -static
 minicriu : LDLIBS += -lpthread
 minicriu.o : CFLAGS += -fPIE
 
+minicriu-client : LDLIBS += -lpthread
 minicriu-client.o : CFLAGS += -fPIC
 
 libminicriu-client.a : minicriu-client.o
@@ -52,7 +53,7 @@ set-core-pattern :
 	echo /tmp/core.%p | sudo tee /proc/sys/kernel/core_pattern
 
 core : test file
-	grep '^/tmp/core.%p$$' /proc/sys/kernel/core_pattern # assume the specific core_pattern
+#	grep '^/tmp/core.%p$$' /proc/sys/kernel/core_pattern # assume the specific core_pattern
 	export LD_LIBRARY_PATH=$$PWD; bash -c 'echo $$$$ > /tmp/test.pid; ulimit -c unlimited; exec ./$<'; mv /tmp/core.$$(cat /tmp/test.pid) $@
 	rm /tmp/test.pid
 

--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,7 @@ set-core-pattern :
 	echo /tmp/core.%p | sudo tee /proc/sys/kernel/core_pattern
 
 core : test file
-#	grep '^/tmp/core.%p$$' /proc/sys/kernel/core_pattern # assume the specific core_pattern
-	export LD_LIBRARY_PATH=$$PWD; bash -c 'echo $$$$ > /tmp/test.pid; ulimit -c unlimited; exec ./$<'; mv /tmp/core.$$(cat /tmp/test.pid) $@
-	rm /tmp/test.pid
+	export LD_LIBRARY_PATH=$$PWD; exec ./$<; 
 
 sim-run : test
 	gdb -q -batch -ex 'handle SIGABRT noprint nostop nopass' -ex 'run' ./test

--- a/minicriu-client.c
+++ b/minicriu-client.c
@@ -615,53 +615,6 @@ int minicriu_dump(void) {
 
 	writefile("/proc/self/comm", comm, commlen);
 
-#if 0
-	FILE *f = fopen("/proc/self/maps", "r");
-	char line[4096];
-	while (fgets(line, sizeof(line), f)) {
-		if (!strstr(line, "proj/minicriu/minicriu")) {
-			continue;
-		}
-		char *low, *high;
-		if (sscanf(line, "%p-%p", &low, &high) != 2) {
-			continue;
-		}
-		if (munmap(low, high - low)) {
-			perror("munmap");
-		}
-	}
-
-	int fd = open("./test", O_RDONLY);
-	if (fd < 0) {
-		perror("open ./test");
-		return 0;
-	}
-
-	if (syscall(SYS_prctl, PR_SET_MM, PR_SET_MM_EXE_FILE, fd, 0, 0)) {
-		perror("prctl EXE_FILE");
-	}
-#endif
-
-#if 0
-	char *stack = mmap(NULL, 1 * 4096,
-		PROT_READ | PROT_WRITE,
-		MAP_PRIVATE | MAP_GROWSDOWN | MAP_ANONYMOUS,
-		-1, 0);
-	if (stack == MAP_FAILED) {
-		perror("mmap stack");
-	}
-	char *cmd = strcpy(stack, "./test");
-	printf("cmd = %p\n", cmd);
-
-	if (prctl(PR_SET_MM, PR_SET_MM_ARG_START, cmd, 0, 0)) {
-		perror("PR_SET_MM_ARG_START");
-	}
-	printf("end = %p\n", cmd + strlen(cmd) + 1);
-	if (prctl(PR_SET_MM, PR_SET_MM_ARG_END, cmd + strlen(cmd) + 1), 0, 0) {
-		perror("PR_SET_MM_ARG_END");
-	}
-#endif
-
 	mc_futex_restore = 1;
 	syscall(SYS_futex, &mc_futex_restore, FUTEX_WAKE, INT_MAX);
 

--- a/minicriu-client.c
+++ b/minicriu-client.c
@@ -42,16 +42,46 @@
 #include <sys/prctl.h>
 #include <sys/mman.h>
 #include <linux/futex.h>
+#include <sys/procfs.h>
+#include <pthread.h>
+#include <elf.h>
+#include <asm/prctl.h>
 
 #include "minicriu-client.h"
 
 #define MC_THREAD_SIG SIGSYS
+#define MC_GET_REGISTERS SIGUSR1
 #define MC_MAX_MAPS 512
+#define MC_MAX_PHDRS 512
+#define MC_MAX_THREADS 64
+#define MC_OWNER_SIZE 5
+#define MC_NOTE_PADDING 4
+
+// Enable or disable debug logging
+#define DEBUG 0
+
+#if DEBUG
+	#define debug_log(fmt, ...) printf(fmt, ##__VA_ARGS__)
+#else
+	#define debug_log
+#endif
+
+Elf64_Ehdr ehdr;
+Elf64_Phdr phdr[MC_MAX_PHDRS];
+Elf64_Nhdr nhdr[MC_MAX_THREADS];
+struct elf_prstatus prstatus[MC_MAX_THREADS];
+
+static pthread_mutex_t mc_getregs_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_barrier_t mc_thread_barrier;
+static volatile int mc_gregs_counter;
+static volatile int mc_thread_counter;
 
 static volatile uint32_t mc_futex_checkpoint;
 static volatile uint32_t mc_futex_restore;
 static volatile uint32_t mc_restored_threads;
 int mc_mapscnt;
+static volatile uint32_t mc_barrier_initialization;
+
 
 static void mc_sighnd(int sig);
 static int mc_getmap();
@@ -112,12 +142,306 @@ static int writefile(const char *file, const char *buf, size_t len) {
 	return bytes;
 }
 
+static unsigned long align_up(unsigned long v, unsigned p) {
+	return (v + p - 1) & ~(p - 1);
+}
+
+static int mc_save_core_file() {
+
+	pid_t pid = syscall(SYS_getpid);
+	int phnum = 0;
+
+	// Create Elf header
+	memset(&ehdr, 0, sizeof(ehdr));
+	memcpy(ehdr.e_ident, ELFMAG, SELFMAG);
+	ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+	#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	ehdr.e_ident[EI_DATA] = ELFDATA2LSB;
+	#else
+	ehdr.e_ident[EI_DATA] = ELFDATA2MSB;
+	#endif
+	ehdr.e_ident[EI_VERSION] = EV_CURRENT;
+	ehdr.e_ident[EI_OSABI] = ELFOSABI_SYSV;
+	ehdr.e_type = ET_CORE;
+	ehdr.e_machine = EM_X86_64;
+	ehdr.e_version = EV_CURRENT;
+	ehdr.e_phoff = sizeof(Elf64_Ehdr);
+	ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+	ehdr.e_phentsize = sizeof(Elf64_Phdr);
+
+	// Create PT_NOTE phdr
+	phdr[phnum].p_type = PT_NOTE;
+	phdr[phnum].p_flags = 0;
+	phdr[phnum].p_offset = 0;
+	phdr[phnum].p_vaddr = 0;
+	phdr[phnum].p_paddr = 0;
+	phdr[phnum].p_memsz = 0;
+	phdr[phnum].p_filesz = 0;
+	phdr[phnum++].p_align = 0;
+
+	FILE *proc_maps = fopen("/proc/self/maps", "r");
+	if (proc_maps == NULL) {
+		perror("Could not open maps file. Failed to create checkpoint.");
+		return 1;
+	}
+
+	struct  nt_note {
+		long count;
+		long page_size;
+		long descsz;
+		struct filemap
+		{
+			long start;
+			long end;
+			long fileofs;
+		} filemaps[MC_MAX_PHDRS];
+		char filepath[MC_MAX_PHDRS][512];
+	} nt_file;
+
+	// Initialize NT_FILE
+	nt_file.descsz = 0;
+	nt_file.descsz += sizeof(nt_file.count) + sizeof(nt_file.page_size);
+	nt_file.page_size = 0x1000;
+
+	// Create PT_LOAD and NT_FILE phdrs
+	char buffer[256];
+	while (fgets(buffer, sizeof(buffer), proc_maps)) {
+		void *addr_start, *addr_end;
+		char perms[8];
+		long ofs;
+		int name_start = 0;
+		int name_end = 0;
+
+		int res = sscanf(buffer, "%p-%p %7s %lx %*d:%*d %*x %n%*[^\n]%n", &addr_start,
+			&addr_end, perms, &ofs, &name_start, &name_end);
+
+		if (res < 4) {
+			perror("sscanf. Failed to create checkpoint.");
+			fclose(proc_maps);
+			return 1;
+		}
+
+		// [vsyscall] is mapped to the same address in each process
+		if (!strncmp(buffer + name_start, "[vsyscall]", sizeof("[vsyscall]") - 1)) {
+			continue;
+		}
+
+		// Save mapped files
+		if (name_end > name_start && *(buffer + name_start) != '[') {
+			int count = nt_file.count;
+			nt_file.filemaps[count].start = (long int)addr_start;
+			nt_file.filemaps[count].end = (long int)addr_end;
+			nt_file.filemaps[count].fileofs = ofs / nt_file.page_size;
+			memcpy(nt_file.filepath[count], buffer + name_start, name_end - name_start);
+			nt_file.filepath[count][name_end - name_start] = '\0';
+			nt_file.descsz += sizeof(struct filemap) + name_end - name_start + 1;
+			nt_file.count++;
+		}
+
+		phdr[phnum].p_type = PT_LOAD;
+		phdr[phnum].p_flags = 0;
+		phdr[phnum].p_flags |= perms[0] == 'r' ? PF_R : 0;
+		phdr[phnum].p_flags |= perms[1] == 'w' ? PF_W : 0;
+		phdr[phnum].p_flags |= perms[2] == 'x' ? PF_X : 0;
+		phdr[phnum].p_offset = 0;
+		phdr[phnum].p_vaddr = (long unsigned int)addr_start;
+		phdr[phnum].p_paddr = 0;
+		phdr[phnum].p_memsz = addr_end - addr_start;
+		phdr[phnum].p_filesz = phdr[phnum].p_flags != 0 ? addr_end - addr_start : 0;
+		phdr[phnum++].p_align = 0x1000;
+	}
+
+	fclose(proc_maps);
+
+	// Updating headers
+	ehdr.e_phnum = phnum;
+	int prstatus_sz = mc_thread_counter * (sizeof(Elf64_Nhdr) + sizeof(struct elf_prstatus) + align_up(MC_OWNER_SIZE, 4));
+	int ntfile_sz = sizeof(Elf64_Nhdr) + align_up(nt_file.descsz, 4) + align_up(MC_OWNER_SIZE, 4);
+	phdr[0].p_filesz = prstatus_sz + ntfile_sz;
+	phdr[0].p_offset = sizeof(Elf64_Ehdr) + ehdr.e_phnum * ehdr.e_phentsize;
+	for (int i = 1; i < phnum; i++) {
+		phdr[i].p_offset = align_up(phdr[i - 1].p_offset + phdr[i - 1].p_filesz, phdr[i].p_align);
+	}
+
+	char filename[32];
+	sprintf(filename, "minicriu-core.%d", pid);
+	FILE *coreFile = fopen(filename, "w+");
+	if (coreFile == NULL) {
+		perror("Could not create file for minicriu dump. Failed to create checkpoint.");
+		return 1;
+	}
+	int bytesWritten = 0;
+
+	// Write elf header
+	fwrite(&ehdr, sizeof(Elf64_Ehdr), 1, coreFile);
+	bytesWritten += sizeof(Elf64_Ehdr);
+
+	// Write phdrs
+	fwrite(phdr, sizeof(Elf64_Phdr), phnum, coreFile);
+	bytesWritten += sizeof(Elf64_Phdr) * phnum;
+
+	char owner[] = "CORE"; // "CORE" gives more information while reading using readelf and eu-readelf tools
+	char paddingData[0x1000];
+	memset(paddingData, 0x0, 0x1000);
+	int thread_counter = mc_thread_counter;
+
+	// Write PRSTATUS data for every process thread
+	int notes_size = 0;
+	for (int i = 0; i < thread_counter; i++) {
+		Elf64_Nhdr *cur_nhdr = &nhdr[i];
+
+		cur_nhdr->n_namesz = sizeof(owner);
+		cur_nhdr->n_descsz = sizeof(struct elf_prstatus);
+		cur_nhdr->n_type = NT_PRSTATUS;
+
+		fwrite(cur_nhdr, sizeof(Elf64_Nhdr), 1, coreFile);
+		bytesWritten += sizeof(Elf64_Nhdr);
+		notes_size += sizeof(Elf64_Nhdr);
+
+		fwrite(owner, sizeof(owner), 1, coreFile);
+		bytesWritten += sizeof(owner);
+		notes_size += sizeof(owner);
+
+		if (cur_nhdr->n_namesz % MC_NOTE_PADDING != 0) {
+			int padding = align_up(bytesWritten, MC_NOTE_PADDING) - bytesWritten;
+			fwrite(paddingData, padding, 1, coreFile);
+			bytesWritten += padding;
+			notes_size += padding;
+		}
+
+		fwrite(&prstatus[i], sizeof(struct elf_prstatus), 1, coreFile);
+		bytesWritten += sizeof(struct elf_prstatus);
+		notes_size += sizeof(struct elf_prstatus);
+
+		if (cur_nhdr->n_descsz % MC_NOTE_PADDING != 0) {
+			int padding = align_up(bytesWritten, MC_NOTE_PADDING) - bytesWritten;
+			fwrite(paddingData, padding, 1, coreFile);
+			bytesWritten += padding;
+			notes_size += padding;
+		}
+	}
+
+	// Write NT_FILE
+	Elf64_Nhdr *cur_nhdr = &nhdr[thread_counter];
+	cur_nhdr->n_namesz = sizeof(owner);
+	cur_nhdr->n_descsz = nt_file.descsz;
+	cur_nhdr->n_type = NT_FILE;
+
+	fwrite(cur_nhdr, sizeof(Elf64_Nhdr), 1, coreFile);
+	bytesWritten += sizeof(Elf64_Nhdr);
+	notes_size += sizeof(Elf64_Nhdr);
+
+	fwrite(owner, sizeof(owner), 1, coreFile);
+	bytesWritten += sizeof(owner);
+	notes_size += sizeof(owner);
+
+	if (cur_nhdr->n_namesz % MC_NOTE_PADDING != 0) {
+		int padding = align_up(bytesWritten, MC_NOTE_PADDING) - bytesWritten;
+		fwrite(paddingData, padding, 1, coreFile);
+		bytesWritten += padding;
+		notes_size += padding;
+	}
+
+	fwrite(&nt_file, sizeof(nt_file.count) + sizeof(nt_file.page_size), 1, coreFile);
+	fwrite(&nt_file.filemaps, sizeof(struct filemap), nt_file.count, coreFile);
+	for (int i = 0; i < nt_file.count; i++) {
+		fputs(nt_file.filepath[i], coreFile);
+		fputc('\0', coreFile);
+	}
+
+	if (cur_nhdr->n_descsz % MC_NOTE_PADDING != 0) {
+		int padding = align_up(bytesWritten, MC_NOTE_PADDING) - bytesWritten;
+		fwrite(paddingData, padding, 1, coreFile);
+		bytesWritten += padding;
+		notes_size += padding;
+	}
+
+	// Write PT_LOAD
+	for (int i = 1; i < phnum; i++) {
+		if (phdr[i].p_filesz != 0) {
+			int padding = phdr[i].p_offset - (phdr[i - 1].p_offset + phdr[i - 1].p_filesz);
+			if (padding > 0) {
+				fwrite(paddingData, sizeof(paddingData), padding / sizeof(paddingData), coreFile);
+				fwrite(paddingData, padding % sizeof(paddingData), 1, coreFile);
+			}
+
+			int written = fwrite((void *)phdr[i].p_vaddr, 1, phdr[i].p_filesz, coreFile);
+
+			if (written != phdr[i].p_filesz) {
+				perror("Failed write map content");
+
+				// As a temporary solution we fill the unwritten data with zeros
+				int leftData = phdr[i].p_filesz - written;
+				int n = leftData / sizeof(paddingData);
+
+				int writtenZeroes = fwrite(paddingData, sizeof(paddingData), n, coreFile);
+				if (writtenZeroes != n) {
+					perror("Failed replace map content with zeroes. Failed to create checkpoint.");
+					fclose(coreFile);
+					return 1;
+				}
+
+				leftData = leftData % sizeof(paddingData);
+				if (leftData) {
+					if (fwrite(paddingData, leftData, 1, coreFile)) {
+						perror("Failed replace map content with zeroes. Failed to create checkpoint.");
+						fclose(coreFile);
+						return 1;
+					}
+				}
+			}
+		}
+	}
+
+	fclose(coreFile);
+	return 0;
+}
+
+static void mc_make_core(int sig, siginfo_t *info, void *ctx) {
+	ucontext_t *uc = (ucontext_t *)ctx;
+	greg_t *gregs = uc->uc_mcontext.gregs;
+	int thread_id = gregs[REG_RDX]; // get extra argument
+
+	struct user_regs_struct *uregs = (void *)prstatus[thread_id].pr_reg;
+	uregs->r15 = gregs[REG_R15];
+	uregs->r14 = gregs[REG_R14];
+	uregs->r13 = gregs[REG_R13];
+	uregs->r12 = gregs[REG_R12];
+	uregs->rbp = gregs[REG_RBP];
+	uregs->rbx = gregs[REG_RBX];
+	uregs->r11 = gregs[REG_R11];
+	uregs->r10 = gregs[REG_R10];
+	uregs->r9 = gregs[REG_R9];
+	uregs->r8 = gregs[REG_R8];
+	uregs->rax = gregs[REG_RAX];
+	uregs->rcx = gregs[REG_RCX];
+	uregs->rdx = gregs[REG_RDX];
+	uregs->rsi = gregs[REG_RSI];
+	uregs->rdi = gregs[REG_RDI];
+	uregs->rip = gregs[REG_RIP];
+	uregs->eflags = gregs[REG_EFL];
+	uregs->rsp = gregs[REG_RSP];
+	syscall(SYS_arch_prctl, ARCH_GET_FS, &(uregs->fs_base));
+	syscall(SYS_arch_prctl, ARCH_GET_GS, &(uregs->gs_base));
+
+	prstatus[thread_id].pr_pid = syscall(SYS_gettid);
+
+	// Wait until all threads save their registers
+	pthread_barrier_wait(&mc_thread_barrier);
+	if (thread_id == mc_thread_counter - 1) {
+		mc_save_core_file();
+	}
+
+	// Wait for all data to be saved. Otherwise the stack data will probably be corrupted.
+	pthread_barrier_wait(&mc_thread_barrier);
+}
+
 int minicriu_dump(void) {
 
 	pid_t mytid = syscall(SYS_gettid);
 	pid_t mypid = getpid();
 
-	printf("minicriu thread %d\n", mytid);
+	debug_log("minicriu thread %d\n", mytid);
 
 	char auxv[1024];
 	int auxvlen = readfile("/proc/self/auxv", auxv, sizeof(auxv));
@@ -126,7 +450,7 @@ int minicriu_dump(void) {
 	}
 
 	char comm[1024];
-	int commlen = readfile("/proc/self/comm", auxv, sizeof(auxv));
+	int commlen = readfile("/proc/self/comm", comm, sizeof(comm));
 	if (commlen < 0) {
 		fprintf(stderr, "read comm: %s\n", strerror(commlen));
 	}
@@ -134,23 +458,34 @@ int minicriu_dump(void) {
 	struct savedctx ctx;
 	SAVE_CTX(ctx);
 
-	struct sigaction newhnd = { .sa_handler = mc_sighnd };
-	struct sigaction oldhnd;
+	struct sigaction newhnd1 = { .sa_handler = mc_sighnd };
+	struct sigaction newhnd2 = {
+		.sa_sigaction = mc_make_core,
+		.sa_flags = SA_SIGINFO
+	};
 
-	if (sigaction(MC_THREAD_SIG, &newhnd, &oldhnd)) {
+	struct sigaction oldhnd1;
+	struct sigaction oldhnd2;
+
+	if (sigaction(MC_THREAD_SIG, &newhnd1, &oldhnd1)) {
 		perror("sigaction");
 		return 1;
 	}
 
-	DIR* tasksdir = opendir("/proc/self/task/");
+	if (sigaction(MC_GET_REGISTERS, &newhnd2, &oldhnd2)) {
+		perror("sigaction");
+		return 1;
+	}
+
+	int thread_counter = 0;
+	DIR *tasksdir = opendir("/proc/self/task/");
 	struct dirent *taskdent;
-	int thread_n = 0;
 	while ((taskdent = readdir(tasksdir))) {
 		if (taskdent->d_name[0] == '.') {
 			continue;
 		}
 		int tid = atoi(taskdent->d_name);
-		printf("minicriu %d me %d\n", tid, mytid == tid);
+		debug_log("minicriu %d me %d\n", tid, mytid == tid);
 		if (tid == mytid) {
 			continue;
 		}
@@ -158,45 +493,52 @@ int minicriu_dump(void) {
 			/* don't touch premodorial thread */
 			continue;
 		}
-		thread_n++;
 		int r = syscall(SYS_tkill, tid, MC_THREAD_SIG);
 		__atomic_fetch_sub(&mc_futex_checkpoint, 1, __ATOMIC_SEQ_CST);
+		thread_counter++;
 	}
 	closedir(tasksdir);
+
+	mc_thread_counter = thread_counter + 1;
+	debug_log("thread_counter = %d\n", thread_counter);
 
 	uint32_t current_count;
 	while ((current_count = mc_futex_checkpoint) != 0) {
 		syscall(SYS_futex, &mc_futex_checkpoint, FUTEX_WAIT, current_count);
 	}
 
-	struct sigaction acts[SIGRTMAX];
-	struct sigaction new = { .sa_handler = SIG_DFL };
-	for (int i = 1; i < SIGRTMAX; ++i) {
-		if (sigaction(i, &new, &acts[i])) {
-			char msg[256];
-			snprintf(msg, sizeof(msg), "sigaction checkpoint %d: %m", i);
-			fprintf(stderr, "%s\n", msg);
-		}
-	}
+	// Initialize barrier
+	pthread_barrier_init(&mc_thread_barrier, NULL, mc_thread_counter);
 
-	acts[MC_THREAD_SIG] = oldhnd;
-	if (mc_getmap())
+	// Say to other threads that barrier is initialized
+	__atomic_fetch_add(&mc_barrier_initialization, 1, __ATOMIC_SEQ_CST);
+	syscall(SYS_futex, &mc_barrier_initialization, FUTEX_WAKE, thread_counter);
+    if (mc_getmap())
 		printf("failed to get maps from /proc/self/maps\n");
 
+    // TODO: save signal handlers
+
 	pid_t pid = syscall(SYS_getpid);
-	syscall(SYS_kill, mytid, SIGABRT, 1313, mytid);
+
+	// Save registers
+	pthread_mutex_lock(&mc_getregs_mutex);
+	int extra_arg = mc_gregs_counter++;
+	pthread_mutex_unlock(&mc_getregs_mutex);
+	int r = syscall(SYS_tkill, syscall(SYS_gettid), MC_GET_REGISTERS, extra_arg);
 
 	RESTORE_CTX(ctx);
 
 	int newtid = syscall(SYS_gettid);
 	*gettid_ptr(pthread_self()) = newtid;
 
-	for (int i = 1; i < SIGRTMAX; ++i) {
-		if (sigaction(i, &acts[i], NULL)) {
-			char msg[256];
-			snprintf(msg, sizeof(msg), "sigaction restore %d: %m", i);
-			fprintf(stderr, "%s\n", msg);
-		}
+	if (sigaction(MC_THREAD_SIG, &oldhnd1, NULL)) {
+		perror("sigaction");
+		return 1;
+	}
+
+	if (sigaction(MC_GET_REGISTERS, &oldhnd2, NULL)) {
+		perror("sigaction");
+		return 1;
 	}
 
 	if ((0 < auxvlen) && (prctl(PR_SET_MM, PR_SET_MM_AUXV, auxv, auxvlen, 0) < 0)) {
@@ -234,9 +576,9 @@ int minicriu_dump(void) {
 
 #if 0
 	char *stack = mmap(NULL, 1 * 4096,
-			PROT_READ | PROT_WRITE,
-			MAP_PRIVATE | MAP_GROWSDOWN | MAP_ANONYMOUS,
-			-1, 0);
+		PROT_READ | PROT_WRITE,
+		MAP_PRIVATE | MAP_GROWSDOWN | MAP_ANONYMOUS,
+		-1, 0);
 	if (stack == MAP_FAILED) {
 		perror("mmap stack");
 	}
@@ -260,7 +602,7 @@ int minicriu_dump(void) {
 	*	munmap segments before the threads are restored
 	*/
 
-	while ((current_count = mc_restored_threads) != thread_n) {
+	while ((current_count = mc_restored_threads) != thread_counter) {
 		syscall(SYS_futex, &mc_restored_threads, FUTEX_WAIT, current_count);
 	}
 
@@ -281,19 +623,30 @@ static void mc_sighnd(int sig) {
 
 	struct savedctx ctx;
 	SAVE_CTX(ctx);
-
 	int tid = syscall(SYS_gettid);
+	debug_log("(%d) fsbase %lx gsbase %lx\n", tid, ctx.fsbase, ctx.gsbase);
 
 	pthread_t self = pthread_self();
 	pid_t *tidptr = gettid_ptr(self);
 	pthread_kill(self, 0);
 
-	char buf[256];
-	int len = snprintf(buf, sizeof(buf), "%s: self %p tidptr %p *tidptr %d\n",
-			__func__, self, tidptr, *tidptr);
-	write(2, buf, len);
+	debug_log("%s: self %ld tidptr %p *tidptr %d\n",
+		__func__, self, tidptr, *tidptr);
 
 	assert(*gettid_ptr(pthread_self()) == tid);
+
+	// Make sure that barrier was initialized
+	uint32_t current_count;
+	while ((current_count = mc_barrier_initialization) == 0) {
+		syscall(SYS_futex, &mc_barrier_initialization, FUTEX_WAIT, current_count);
+	}
+
+	// Save registers
+	pthread_mutex_lock(&mc_getregs_mutex);
+	int extra_arg = mc_gregs_counter++;
+	pthread_mutex_unlock(&mc_getregs_mutex);
+	int r = syscall(SYS_tkill, syscall(SYS_gettid), MC_GET_REGISTERS, extra_arg);
+
 
 	while (!mc_futex_restore) {
 		// syscall sets thread-local errno while thread-local

--- a/minicriu-client.c
+++ b/minicriu-client.c
@@ -38,7 +38,7 @@
 #include <pthread.h>
 #include <signal.h>
 #include <fcntl.h>
-#include <sys/syscall.h>      /* Definition of SYS_* constants */
+#include <sys/syscall.h>	/* Definition of SYS_* constants */
 #include <sys/prctl.h>
 #include <sys/mman.h>
 #include <linux/futex.h>
@@ -92,8 +92,8 @@ struct savedctx {
 };
 
 struct mc_map {
-    void *start;
-    void *end;
+	void *start;
+	void *end;
 } maps[MC_MAX_MAPS];
 
 #define SAVE_CTX(ctx) do { \
@@ -368,25 +368,25 @@ static int mc_save_core_file() {
 			int written = fwrite((void *)phdr[i].p_vaddr, 1, phdr[i].p_filesz, coreFile);
 
 			if (written != phdr[i].p_filesz) {
-			    // This happens when the mapping is larger than the mapped file (rounded up to page size)
-			    // - errno is EFAULT. Accessing that memory directly would result in SIGBUS.
+				// This happens when the mapping is larger than the mapped file (rounded up to page size)
+				// - errno is EFAULT. Accessing that memory directly would result in SIGBUS.
 				if (errno != EFAULT) {
-				    perror("Failed write map content");
-				    return 1;
+					perror("Failed write map content");
+					return 1;
 				}
 
 				// We fill the unwritten data with zeros
 				int leftData = phdr[i].p_filesz - written;
 				do {
-				    int n = leftData < sizeof(paddingData) ? leftData : sizeof(paddingData);
+					int n = leftData < sizeof(paddingData) ? leftData : sizeof(paddingData);
 
-                    int writtenZeroes = fwrite(paddingData, 1, n, coreFile);
-                    if (writtenZeroes == 0) {
-                        perror("Failed replace map content with zeroes. Failed to create checkpoint.");
-                        fclose(coreFile);
-                        return 1;
-                    }
-                    leftData -= writtenZeroes;
+					int writtenZeroes = fwrite(paddingData, 1, n, coreFile);
+					if (writtenZeroes == 0) {
+						perror("Failed replace map content with zeroes. Failed to create checkpoint.");
+						fclose(coreFile);
+						return 1;
+					}
+					leftData -= writtenZeroes;
 				} while (leftData > 0);
 
 				leftData = leftData % sizeof(paddingData);
@@ -521,10 +521,10 @@ int minicriu_dump(void) {
 	// Say to other threads that barrier is initialized
 	__atomic_fetch_add(&mc_barrier_initialization, 1, __ATOMIC_SEQ_CST);
 	syscall(SYS_futex, &mc_barrier_initialization, FUTEX_WAKE, thread_counter);
-    if (mc_getmap())
+	if (mc_getmap())
 		printf("failed to get maps from /proc/self/maps\n");
 
-    // TODO: save signal handlers
+	// TODO: save signal handlers
 
 	pid_t pid = syscall(SYS_getpid);
 

--- a/minicriu-client.h
+++ b/minicriu-client.h
@@ -30,8 +30,6 @@
 extern "C" {
 #endif
 
-extern int minicriu_register_new_thread(void);
-
 extern int minicriu_dump(void);
 
 #ifdef __cplusplus

--- a/minicriu.c
+++ b/minicriu.c
@@ -52,8 +52,6 @@
 #include <limits.h>
 
 
-static struct elf_prpsinfo *prpsinfo;
-
 #define MAX_THREADS 128
 #define MAX_FILEMAPS 1024
 
@@ -189,7 +187,8 @@ static void visit_note(off_t nameoff, off_t doff, const Elf64_Nhdr *nh) {
 	void *target = NULL;
 	if (!strcmp("CORE", rawelf + nameoff)) {
 		switch (nh->n_type) {
-		case NT_PRPSINFO: target = &prpsinfo; break;
+		// We ignore PRPSINFO (if present): the values might be truncated anyway
+		// so we cannot rely on this for restore.
 		case NT_PRSTATUS: target = &prstatus[thread_n++]; break;
 		case NT_PRFPREG:  target = &prfpreg[thread_n];  break;
 		case NT_AUXV:

--- a/minicriu.c
+++ b/minicriu.c
@@ -42,8 +42,8 @@
 #include <sys/procfs.h>
 #include <sys/stat.h>
 #include <sys/ucontext.h>
-#include <asm/prctl.h>        /* Definition of ARCH_* constants */
-#include <sys/syscall.h>      /* Definition of SYS_* constants */
+#include <asm/prctl.h>		/* Definition of ARCH_* constants */
+#include <sys/syscall.h>	  /* Definition of SYS_* constants */
 #include <linux/sched.h>
 #include <linux/elf.h>
 
@@ -305,8 +305,8 @@ int main(int argc, char *argv[]) {
 
 	for (int i = 1; i < thread_n; ++i) {
 		const int flags = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM
-                           | CLONE_SIGHAND | CLONE_THREAD;
-                           /*| CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID*/
+			| CLONE_SIGHAND | CLONE_THREAD;
+			/*| CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID*/
 #if 0
 		static_assert(sizeof(stack[i]) == 4 * 4096);
 		struct clone_args args = {

--- a/minicriu.c
+++ b/minicriu.c
@@ -46,11 +46,13 @@
 #include <sys/syscall.h>	  /* Definition of SYS_* constants */
 #include <linux/sched.h>
 #include <linux/elf.h>
+#include <limits.h>
 
 
 static struct elf_prpsinfo *prpsinfo;
 
 #define MAX_THREADS 128
+#define MAX_FILEMAPS 1024
 
 static int thread_n;
 static struct elf_prstatus *prstatus[MAX_THREADS];
@@ -61,6 +63,7 @@ static pthread_barrier_t thread_barrier;
 
 static size_t elfsz;
 static void *rawelf;
+static void *nt_file_start = NULL;
 
 static void arch_prctl(int code, unsigned long addr) {
 	if (syscall(SYS_arch_prctl, code, addr)) {
@@ -140,23 +143,112 @@ static int clonefn(void *arg) {
 	return 1;
 }
 
+static int is_conflict(void *p1, size_t s1, void *p2, size_t s2) {
+	return (p1 >= p2 && p1 < p2 + s2) || (p2 >= p1 && p2 < p1 + s1);
+}
+
+static const Elf64_Phdr *find_notes(const Elf64_Ehdr *ehdr, const Elf64_Phdr *phdrs) {
+	for (int i = 0; i < ehdr->e_phnum; ++i) {
+		const Elf64_Phdr *ph = phdrs + i;
+		if (ph->p_type == PT_NOTE) {
+			return ph;
+		}
+	}
+	return NULL;
+}
+
+typedef void note_visitor(off_t nameoff, off_t doff, const Elf64_Nhdr *nh);
+
+static void visit_notes(const Elf64_Phdr *ph_notes, note_visitor *visitor) {
+	off_t noff = ph_notes->p_offset;
+	while (noff < ph_notes->p_offset + ph_notes->p_filesz) {
+		Elf64_Nhdr *nh = rawelf + noff;
+		off_t nameoff = noff + sizeof(*nh);
+		off_t doff = nameoff + align_up(nh->n_namesz, 4);
+		noff = doff + align_up(nh->n_descsz, 4);
+
+		visitor(nameoff, doff, nh);
+	}
+}
+
+// what does this really do?
+static void visit_note(off_t nameoff, off_t doff, const Elf64_Nhdr *nh) {
+	void *target = NULL;
+	if (!strcmp("CORE", rawelf + nameoff)) {
+		switch (nh->n_type) {
+		case NT_PRPSINFO: target = &prpsinfo; break;
+		case NT_PRSTATUS: target = &prstatus[thread_n++]; break;
+		case NT_PRFPREG:  target = &prfpreg[thread_n];  break;
+		default: break;
+		}
+	}
+	if (!strcmp("LINUX", rawelf + nameoff)) {
+		switch (nh->n_type) {
+		case NT_X86_XSTATE: break;
+		default: break;
+		}
+	}
+	if (target) {
+		*(void**)target = rawelf + doff;
+	}
+}
+
+static void find_filemap(off_t nameoff, off_t doff, const Elf64_Nhdr *nh) {
+	if (!strcmp("CORE", rawelf + nameoff) && nh->n_type == NT_FILE) {
+		nt_file_start = rawelf + doff;
+	}
+}
+
+static const char *find_file(void *addr, size_t size, size_t *file_offset) {
+	if (nt_file_start == NULL) {
+		return NULL;
+	}
+	struct {
+		long count;
+		long page_size;
+		struct filemap {
+			long start;
+			long end;
+			long file_ofs;
+		} map[0];
+	} *fh = nt_file_start;
+
+	char *name = (char*)(&fh->map[fh->count]);
+	for (int i = 0; i < fh->count; ++i) {
+		struct filemap *fm = &fh->map[i];
+
+		if ((void *) fm->start == addr) {
+			if (fm->end - fm->start != size) {
+				fprintf(stderr, "Mismatched size for %p: mapping says 0x%lx, requesting 0x%lx\n",
+					addr, fm->end - fm->start, size);
+				exit(1);
+			}
+			*file_offset = fm->file_ofs * 0x1000; // page size
+			return name;
+		}
+
+		name = name + strlen(name) + 1;
+	}
+	return NULL;
+}
+
 int main(int argc, char *argv[]) {
 	const char* elfpath = argv[1];
 
-	int fd = open(elfpath, O_RDONLY);
-	if (fd < 0) {
+	int core_fd = open(elfpath, O_RDONLY);
+	if (core_fd < 0) {
 		perror("open");
 		return 1;
 	}
 
 	struct stat st;
-	if (fstat(fd, &st)) {
+	if (fstat(core_fd, &st)) {
 		perror("stat");
 		return 1;
 	}
 
 	elfsz = align_up(st.st_size, 4096);
-	rawelf = mmap(NULL, elfsz, PROT_READ, MAP_PRIVATE, fd, 0);
+	rawelf = mmap(NULL, elfsz, PROT_READ, MAP_PRIVATE, core_fd, 0);
 	if (rawelf == MAP_FAILED) {
 		perror("mmap");
 		return 1;
@@ -174,115 +266,92 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 	const Elf64_Phdr *phdrs = (const Elf64_Phdr *) (rawelf + ehdr->e_phoff);
-
-	const Elf64_Phdr *ph_notes = NULL;
-	for (int i = 0; i < ehdr->e_phnum; ++i) {
-		const Elf64_Phdr *ph = phdrs + i;
-		if (ph->p_type == PT_NOTE) {
-			ph_notes = ph;
-			break;
-		}
-	}
-
+	const Elf64_Phdr *ph_notes = find_notes(ehdr, phdrs);
 	if (!ph_notes) {
 		fprintf(stderr, "cannot find PT_NOTE\n");
 		return 1;
 	}
 
+	visit_notes(ph_notes, find_filemap);
+
 	for (int i = 0; i < ehdr->e_phnum; ++i) {
 		const Elf64_Phdr *ph = phdrs + i;
 		if (ph->p_type != PT_LOAD) {
 			continue;
 		}
-		if (munmap((void*)ph->p_vaddr, ph->p_memsz)) {
-			/*perror("munmap");*/
+		// Resolve potential conflict
+		void *vaddr = (void *)ph->p_vaddr;
+		size_t memsz = ph->p_memsz;
+		size_t filesz = ph->p_filesz;
+		size_t offset = ph->p_offset;
+		if (is_conflict(rawelf, elfsz, vaddr, memsz)) {
+			// We should unmap our rawelf, to not leave any chunks scattered around.
+			if (munmap(rawelf, elfsz)) {
+				perror("Cannot unmap coredump");
+			}
 		}
-		void *addr = mmap((void *)ph->p_vaddr,
-						  ph->p_memsz,
+		if (munmap(vaddr, memsz)) {
+			// munmap on are that is not mapped is noop
+			perror("Failure unmapping minicriu mapping");
+		}
+		int fd = -1;
+		size_t file_offset = 0;
+		const char *name = find_file(vaddr, memsz, &file_offset);
+		if (name != NULL) {
+			fd = open(name, O_RDONLY);
+			if (fd < 0) {
+				fprintf(stderr, "Cannot open file %s: %m\n", name);
+				file_offset = 0;
+			}
+		}
+		void *addr = mmap(vaddr, memsz,
 						  PROT_WRITE | PROT_READ,
-						  MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS,
-						  -1, 0);
-		if (addr != (void*)ph->p_vaddr) {
+						  MAP_PRIVATE | MAP_FIXED | (fd < 0 ? MAP_ANONYMOUS : 0),
+						  fd, file_offset);
+		if (addr != vaddr) {
 			if (addr == MAP_FAILED) {
-				fprintf(stderr, "WARN: mmap phdr vaddr %16llx filesz %16llx off %16llx: %m\n",
-						ph->p_vaddr, ph->p_filesz, ph->p_offset);
+				fprintf(stderr, "WARN: mmap %s = %d 0x%lx phdr vaddr %p filesz 0x%lx off 0x%lx: %m\n",
+						name, fd, file_offset, vaddr, filesz, offset);
 			} else {
-				fprintf(stderr, "WARN: mmap phdr target mismatch %llx -> %p\n", ph->p_vaddr, addr);
+				fprintf(stderr, "WARN: mmap phdr target mismatch %p -> %p\n", vaddr, addr);
 			}
+		}
+		close(fd);
+		if (is_conflict(rawelf, elfsz, vaddr, memsz)) {
+			void *old = rawelf;
+			// Remap coredump somewhere else
+			rawelf = mmap(NULL, elfsz, PROT_READ, MAP_PRIVATE, fd, 0);
+			if (rawelf == MAP_FAILED) {
+				perror("mmap coredump");
+				return 1;
+			}
+			fprintf(stderr, "Relocated core dump %p -> %p", old, rawelf);
+			ehdr = (const Elf64_Ehdr *) rawelf;
+			phdrs = (const Elf64_Phdr *) (rawelf + ehdr->e_phoff);
+			ph_notes = find_notes(ehdr, phdrs);
 		}
 	}
 
-	off_t noff = ph_notes->p_offset;
-	while (noff < ph_notes->p_offset + ph_notes->p_filesz) {
-		Elf64_Nhdr *nh = rawelf + noff;
-		off_t nameoff = noff + sizeof(*nh);
-		off_t doff = nameoff + align_up(nh->n_namesz, 4);
-		noff = doff + align_up(nh->n_descsz, 4);
-
-		/*printf("%16s 0x%08lx 0x%08lx\n", rawelf + nameoff, nh->n_type, nh->n_descsz);*/
-		void *target = NULL;
-		if (!strcmp("CORE", rawelf + nameoff)) {
-			switch (nh->n_type) {
-			case NT_PRPSINFO: target = &prpsinfo; break;
-			case NT_PRSTATUS: target = &prstatus[thread_n++]; break;
-			case NT_PRFPREG:  target = &prfpreg[thread_n];  break;
-			default: break;
-			}
-		}
-		if (!strcmp("LINUX", rawelf + nameoff)) {
-			switch (nh->n_type) {
-			case NT_X86_XSTATE: break;
-			default: break;
-			}
-		}
-		if (target) {
-			*(void**)target = rawelf + doff;
-		}
-
-		if (!strcmp("CORE", rawelf + nameoff) && nh->n_type == NT_FILE) {
-			struct {
-				long count;
-				long page_size;
-				struct filemap {
-					long start;
-					long end;
-					long file_ofs;
-				} map[0];
-			} *fh = rawelf + doff;
-
-			char *name = (char*)(&fh->map[fh->count]);
-			for (int i = 0; i < fh->count; ++i) {
-				struct filemap *fm = &fh->map[i];
-
-				int fd = open(name, O_RDONLY);
-				munmap((void*)fm->start, fm->end - fm->start);
-				void *addr = mmap((void*)fm->start,
-						fm->end - fm->start,
-						PROT_READ | PROT_WRITE | PROT_EXEC,
-						MAP_FIXED | MAP_PRIVATE,
-						fd, fm->file_ofs * fh->page_size);
-				if (addr != (void*)fm->start) {
-					if (addr == MAP_FAILED) {
-						perror("mmap file");
-					} else {
-						fprintf(stderr, "mmap mismatch 2\n");
-					}
-					return 1;
-				}
-				close(fd);
-
-				name = name + strlen(name) + 1;
-			}
-		}
-	}
-
+	visit_notes(ph_notes, visit_note);
 
 	for (int i = 0; i < ehdr->e_phnum; ++i) {
 		const Elf64_Phdr *ph = phdrs + i;
 		if (ph->p_type != PT_LOAD) {
 			continue;
 		}
-		pread(fd, (void*)ph->p_vaddr, ph->p_filesz, ph->p_offset);
+		size_t total = 0;
+		while (total < ph->p_filesz) {
+			size_t read = pread(core_fd, (void*)ph->p_vaddr, ph->p_filesz - total, ph->p_offset + total);
+			if (read < 0) {
+				perror("Failed to read in memory");
+				return 1;
+			} else if (read == 0) {
+				fprintf(stderr, "Cannot read data for %llx (section %d/%d, offset %llx) (EOF): read %lu/%llu bytes\n",
+					ph->p_vaddr, i, ehdr->e_phnum, ph->p_offset + total, total, ph->p_filesz);
+				return 1;
+			}
+			total += read;
+		}
 
 		int mprot = 0;
 		mprot |= ph->p_flags & PF_R ? PROT_READ : 0;

--- a/minicriu.c
+++ b/minicriu.c
@@ -399,6 +399,8 @@ int main(int argc, char *argv[]) {
 #endif
 	}
 
+	// TODO: auxv info is now in the core dump, restore it if we have the CAP_SYS_RESOURCE permission
+
 	clonefn((void*)(uintptr_t)0);
 	fprintf(stderr, "should not reach here\n");
 	return 0;

--- a/shared.c
+++ b/shared.c
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <unistd.h>
 #include <sys/syscall.h>      /* Definition of SYS_* constants */
 
 #include "shared.h"

--- a/test.c
+++ b/test.c
@@ -25,6 +25,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <unistd.h>
 #include <pthread.h>
@@ -69,8 +70,9 @@ void *thread(void *arg) {
 	printf("tid %d\n", old);
 
 	while (1) {
-		printf("THREAD old tid %d new tid %d local %d\n", old, gettid(), shared_fn());
-		do_kill(main_thread, "kill main");
+		fprintf(stderr, "THREAD old tid %d new tid %d local %d\n", old, gettid(), shared_fn());
+// Not sending signals: Signal restore was removed
+//		do_kill(main_thread, "kill main");
 		usleep(300000);
 	}
 }
@@ -95,17 +97,21 @@ int main(int argc, char *argv[]) {
 	*(int*)addr = 1;
 
 	pid_t oldpid = getpid();
-	printf("pid %ld\n", oldpid);
+	printf("pid %d\n", oldpid);
 
 	thr_local = -gettid();
 
 	pthread_t other;
 	pthread_create(&other, NULL, thread, NULL);
 
-	sleep(100);
+//  This sleep would be interrupted by do_kill
+//	sleep(100);
 
 	if (argc == 1) {
-		minicriu_dump();
+		if (minicriu_dump()) {
+		    fprintf(stderr, "TEST FAILED\n");
+		    exit(1);
+		}
 	}
 
 	printf("done\n");
@@ -117,8 +123,8 @@ int main(int argc, char *argv[]) {
 	printf("done2\n");
 
 	while (1) {
-		printf("MAIN pid old %ld new %ld local %d\n", oldpid, getpid(), shared_fn());
-		do_kill(other, "kill other");
+		printf("MAIN pid old %d new %d tid %d local %d\n", oldpid, getpid(), gettid(), shared_fn());
+//		do_kill(other, "kill other");
 		sleep(1);
 	}
 

--- a/test.c
+++ b/test.c
@@ -32,6 +32,7 @@
 #include <signal.h>
 #include <sys/fcntl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>      /* Definition of SYS_* constants */
 
 #include "minicriu-client.h"
@@ -88,6 +89,13 @@ int main(int argc, char *argv[]) {
 		perror("open");
 		return 1;
 	}
+	struct stat st;
+	if (fstat(fd, &st)) {
+        perror("fstat");
+    } else if (st.st_size != 4096) {
+        fprintf(stderr, "Unexpected size; 'file' should be truncated to 4096 bytes\n");
+        return 1;
+    }
 
 	void *addr = mmap(NULL, 4096 * 1024, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
 	if (addr == MAP_FAILED) {

--- a/test.c
+++ b/test.c
@@ -62,9 +62,6 @@ void sighnd(int sig) {
 }
 
 void *thread(void *arg) {
-
-	minicriu_register_new_thread();
-
 	thr_local = -gettid();
 
 	pid_t old = gettid();
@@ -72,8 +69,7 @@ void *thread(void *arg) {
 
 	while (1) {
 		fprintf(stderr, "THREAD old tid %d new tid %d local %d\n", old, gettid(), shared_fn());
-// Not sending signals: Signal restore was removed
-//		do_kill(main_thread, "kill main");
+		do_kill(main_thread, "kill main");
 		usleep(300000);
 	}
 }
@@ -112,8 +108,7 @@ int main(int argc, char *argv[]) {
 	pthread_t other;
 	pthread_create(&other, NULL, thread, NULL);
 
-//  This sleep would be interrupted by do_kill
-//	sleep(100);
+	sleep(100);
 
 	if (argc == 1) {
 		if (minicriu_dump()) {
@@ -132,7 +127,7 @@ int main(int argc, char *argv[]) {
 
 	while (1) {
 		printf("MAIN pid old %d new %d tid %d local %d\n", oldpid, getpid(), gettid(), shared_fn());
-//		do_kill(other, "kill other");
+		do_kill(other, "kill other");
 		sleep(1);
 	}
 


### PR DESCRIPTION
This supersedes @i-pankrat 's https://github.com/CRaC/minicriu/pull/9, resolving conflicts with updates in master.

The test works only with `GLIBC_TUNABLES=glibc.pthread.rseq=0`, let's leave the fix to another PR. ATM I only know that the SIGSEGV sent with si_code=SI_KERNEL when rseq is enabled originates in this kernel stack trace:
```
           __send_signal_locked 
        __send_signal_locked+0x1 [kernel]
        force_sig_info_to_task+0xf8 [kernel]
        force_sigsegv+0x53 [kernel]
        __rseq_handle_notify_resume+0x68 [kernel]
        exit_to_user_mode_loop+0xf1 [kernel]
        exit_to_user_mode_prepare+0xb9 [kernel]
        syscall_exit_to_user_mode+0x2a [kernel]
        do_syscall_64+0x69 [kernel]
        entry_SYSCALL_64_after_hwframe+0x72 [kernel]
        [unknown]
``` 